### PR TITLE
Avoid using dict for times-waveforms

### DIFF
--- a/hussaini_lab_to_nwb/tint_conversion/export_spike_labels.py
+++ b/hussaini_lab_to_nwb/tint_conversion/export_spike_labels.py
@@ -66,7 +66,6 @@ def write_to_cut_file(cut_filename, unit_labels):
     https://github.com/GeoffBarrett/gebaSpike
     '''
     basename = os.path.basename(os.path.splitext(cut_filename)[0])
-    unique_cells = np.unique(unit_labels)
 
     n_clusters = len(np.unique(unit_labels))
     n_spikes = len(unit_labels)

--- a/hussaini_lab_to_nwb/tint_conversion/export_spike_waveforms.py
+++ b/hussaini_lab_to_nwb/tint_conversion/export_spike_waveforms.py
@@ -116,7 +116,7 @@ def get_waveforms(recording, sorting, unit_ids, header):
         ms_after=ms_after,
         return_idxs=False,
         return_scaled=False,
-        dtype=np.int8,
+        dtype=np.int8
     )
 
     return waveforms


### PR DESCRIPTION
The `TintConverter` used to create a dictionary with times as keys and waveforms as labels before writing the .X files. While with the Axona sorter this is not a problem, using other sorters might result in assigning the same snippet to 2 units, as an overlapping spikes. This makes the use of the dictionary inadequate as keys must be unique.

This PR fixes the tint conversion by keeping separate arrays for spike times and waveforms.