### PR TITLE
Fix tint conversion

### DIFF
--- a/hussaini_lab_to_nwb/tint_conversion/export_spike_labels.py
+++ b/hussaini_lab_to_nwb/tint_conversion/export_spike_labels.py
@@ -120,7 +120,6 @@ def write_to_clu_file(clu_filename, unit_labels):
     https://github.com/GeoffBarrett/gebaSpike
     '''
     unit_labels = np.asarray(unit_labels).astype(int)
-    unit_labels += 1
 
     n_clu = len(np.unique(unit_labels))
     unit_labels = np.concatenate(([n_clu], unit_labels))
@@ -167,6 +166,7 @@ def write_unit_labels_to_file(sorting_extractor, filename):
 
         spike_train = sorting_extractor.get_units_spike_train(unit_ids=unit_ids[tetrode_ids == i])
         unit_labels = convert_spike_train_to_label_array(spike_train)
+        unit_labels += 1
 
         # We use Axona conventions for filenames (tetrodes are 1 indexed)
         cut_filename = set_cut_filename_from_basename(filename, i + 1)

--- a/hussaini_lab_to_nwb/tintconverter.py
+++ b/hussaini_lab_to_nwb/tintconverter.py
@@ -92,6 +92,8 @@ class TintConverter():
             set_file = self.set_file
         else:
             self.set_file = set_file
+        
+        assert 0 < waveforms_center < 1, "'waveforms_center' must be between 0 and 1 ms" 
 
         assert_group_names_match(self.sorting, self.recording)
 

--- a/hussaini_lab_to_nwb/tintconverter.py
+++ b/hussaini_lab_to_nwb/tintconverter.py
@@ -56,7 +56,8 @@ class TintConverter():
         self.sorting = sorting
         self.set_file = set_file
 
-    def write_to_tint(self, recording=None, sorting=None, set_file=None):
+    def write_to_tint(self, recording=None, sorting=None, set_file=None, 
+                      waveforms_center=0.5):
         '''Given recording and sorting extractor objects, write appropriate data
         to TINT format (from Axona). Will therefore create .X (tetrode),
         .cut and .clu (spike sorting information) files.
@@ -71,6 +72,8 @@ class TintConverter():
             the same base filename as the .set file. So if you do not want to overwrite
             existing .X files in your .set file directory, copy the .set file to a new
             folder and give its new location. The new files will appear there.
+        waveforms_center: float
+            Controls the waveform peak location in the 1ms TINT cutout (e.g. 0.5: peak is at 0.5)
 
         Notes
         -----
@@ -94,7 +97,7 @@ class TintConverter():
 
         # writes to .X files for each tetrode
         group_ids = recording.get_channel_groups()
-        write_to_tetrode_files(recording, sorting, group_ids, set_file)
+        write_to_tetrode_files(recording, sorting, group_ids, set_file, waveforms_center)
 
         # writes to .cut and .clu files for each tetrode
         write_unit_labels_to_file(sorting, set_file)


### PR DESCRIPTION
- Fix cell IDs in cut file to avoid using '0' (ID for noise in TINT)
- Added `waveforms_center` argument in `write_to_tint` to control peak location in the 1ms window (e.g. 0.5 means peak is centered)